### PR TITLE
fix(unauthorized-api-calls): change metric alarm threshold to 2

### DIFF
--- a/modules/alarm-baseline/main.tf
+++ b/modules/alarm-baseline/main.tf
@@ -38,7 +38,7 @@ resource "aws_cloudwatch_metric_alarm" "unauthorized_api_calls" {
   namespace                 = var.alarm_namespace
   period                    = "300"
   statistic                 = "Sum"
-  threshold                 = "1"
+  threshold                 = "2"
   alarm_description         = "Monitoring unauthorized API calls will help reveal application errors and may reduce time to detect malicious activity."
   alarm_actions             = [aws_sns_topic.alarms[0].arn]
   treat_missing_data        = "notBreaching"

--- a/modules/alarm-baseline/main.tf
+++ b/modules/alarm-baseline/main.tf
@@ -38,7 +38,7 @@ resource "aws_cloudwatch_metric_alarm" "unauthorized_api_calls" {
   namespace                 = var.alarm_namespace
   period                    = "300"
   statistic                 = "Sum"
-  threshold                 = (var.threshold_unauthorizedapicalls == true ? 2 : 1)
+  threshold                 = (var.metric_unauthorizedapicalls == true ? 2 : 1)
   alarm_description         = "Monitoring unauthorized API calls will help reveal application errors and may reduce time to detect malicious activity."
   alarm_actions             = [aws_sns_topic.alarms[0].arn]
   treat_missing_data        = "notBreaching"

--- a/modules/alarm-baseline/main.tf
+++ b/modules/alarm-baseline/main.tf
@@ -38,7 +38,7 @@ resource "aws_cloudwatch_metric_alarm" "unauthorized_api_calls" {
   namespace                 = var.alarm_namespace
   period                    = "300"
   statistic                 = "Sum"
-  threshold                 = "2"
+  threshold                 = (var.threshold_unauthorizedapicalls == true ? 2 : 1)
   alarm_description         = "Monitoring unauthorized API calls will help reveal application errors and may reduce time to detect malicious activity."
   alarm_actions             = [aws_sns_topic.alarms[0].arn]
   treat_missing_data        = "notBreaching"

--- a/modules/alarm-baseline/variables.tf
+++ b/modules/alarm-baseline/variables.tf
@@ -100,7 +100,13 @@ variable "tags" {
 }
 
 variable "metric_unauthorizedapicalls" {
-  description = "This is whether the value should be either 1 or 2 amount regarding UnauthorizedAPICalls"
+  description = "This is whether the value should be either 1 or 2 amount regarding the metric of UnauthorizedAPICalls"
+  type        = bool
+  default     = true
+}
+
+variable "threshold_unauthorizedapicalls" {
+  description = "This is whether the value should be either 1 or 2 amount regarding the threshold of UnauthorizedAPICalls"
   type        = bool
   default     = true
 }

--- a/modules/alarm-baseline/variables.tf
+++ b/modules/alarm-baseline/variables.tf
@@ -100,13 +100,7 @@ variable "tags" {
 }
 
 variable "metric_unauthorizedapicalls" {
-  description = "This is whether the value should be either 1 or 2 amount regarding the metric of UnauthorizedAPICalls"
-  type        = bool
-  default     = true
-}
-
-variable "threshold_unauthorizedapicalls" {
-  description = "This is whether the value should be either 1 or 2 amount regarding the threshold of UnauthorizedAPICalls"
+  description = "(True/False) controls severity level (1 or 2 calls) for triggering `UnauthorizedAPICalls` alarm"
   type        = bool
   default     = true
 }


### PR DESCRIPTION
This should theoretically fix the CloudWatch alarm to get triggered too quickly, resulting in sending too many webhooks.